### PR TITLE
Bump bounds on optparse-applicative

### DIFF
--- a/hasmin.cabal
+++ b/hasmin.cabal
@@ -35,7 +35,7 @@ executable hasmin
   main-is:             Main.hs
   other-modules:       Paths_hasmin
   build-depends:       base                 >=4.10       && <5.0
-                     , optparse-applicative >=0.11       && <0.15
+                     , optparse-applicative >=0.11       && <0.16
                      , text                 >=1.2        && <1.3
                      , hopfli               >=0.2        && <0.4
                      , bytestring           >=0.10.2.0   && <0.11


### PR DESCRIPTION
Enables use with GHC 8.8.1