### PR TITLE
Some support for unicode-range and @font-face{font-weight}.

### DIFF
--- a/hasmin.cabal
+++ b/hasmin.cabal
@@ -46,7 +46,7 @@ executable hasmin
     , gitrev                >=1.0.0    && <1.4
     , hasmin
     , hopfli                >=0.2      && <0.4
-    , optparse-applicative  >=0.11     && <0.17
+    , optparse-applicative  >=0.11     && <0.18
     , text                  >=1.2      && <1.3
 
   other-modules:    Paths_hasmin


### PR DESCRIPTION
Ref #8.

I don't know or really understand this codebase, but I gave it a shot.

* `unicode-range` now at least doesn't get mangled, although the parser is primitive and doesn't try to minify.

* `font-weight` mostly works, but `font-weight: normal bold` gets changed to `font-weight:700`, which is wrong, and I haven't yet figured out why `normal` gets eaten.  One question is whether it's better to leave this bug or defer support.