### PR TITLE
Update to Haskell Stack LTS 22.5.

### DIFF
--- a/hasmin.cabal
+++ b/hasmin.cabal
@@ -46,8 +46,8 @@ executable hasmin
     , gitrev                >=1.0.0    && <1.4
     , hasmin
     , hopfli                >=0.2      && <0.4
-    , optparse-applicative  >=0.11     && <0.17
-    , text                  >=1.2      && <1.3
+    , optparse-applicative  >=0.11     && <0.19
+    , text                  >=1.2      && <2.1
 
   other-modules:    Paths_hasmin
 
@@ -65,10 +65,10 @@ library
     , base        >=4.10       && <5.0
     , containers  >=0.5        && <0.7
     , matrix      >=0.3.4      && <0.4
-    , mtl         >=2.2.1      && <2.3
+    , mtl         >=2.2.1      && <2.4
     , numbers     >=3000.2.0.0 && <3000.3
     , parsers     >=0.12.3     && <0.13
-    , text        >=1.2        && <1.3
+    , text        >=1.2        && <2.1
 
   -- 'Hasmin.Parser.BasicShape' is exposed because it is needed by tests:
   exposed-modules:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.0
+resolver: lts-22.5
 packages:
 - '.'
 extra-deps:

--- a/tests/Hasmin/TestUtils.hs
+++ b/tests/Hasmin/TestUtils.hs
@@ -40,8 +40,8 @@ minifyWithTestConfig x = runReader (minify x) cfg
   where cfg = defaultConfig { dimensionSettings = DimMinOn }
 
 -- | Check that a color is equivalent to their minified representation form
-prop_minificationEq :: (Minifiable a, Eq a) => a -> Bool
-prop_minificationEq d = minifyWithTestConfig d == d
+prop_minificationEq :: (Minifiable a, Eq a, Show a) => a -> Property
+prop_minificationEq d = minifyWithTestConfig d === d
 
 -- Given a parser and a 3-tuple, prints a test description,
 -- applies the parser, and compares its result with the expected result

--- a/tests/Hasmin/Types/BasicShapeSpec.hs
+++ b/tests/Hasmin/Types/BasicShapeSpec.hs
@@ -17,7 +17,7 @@ basicShapeTests =
   describe "<basic-shape> tests" $ do
     traverse_ (matchSpec f) basicShapeTestsInfo
     modifyMaxSuccess (const 10000) . it "Minified <basic-shape> maintains semantical equivalence" $
-      property (prop_minificationEq :: BasicShape -> Bool)
+      property (prop_minificationEq :: BasicShape -> Property)
   where f :: Parser Value
         f = minifyWithTestConfig <$> value
 

--- a/tests/Hasmin/Types/BgSizeSpec.hs
+++ b/tests/Hasmin/Types/BgSizeSpec.hs
@@ -11,7 +11,7 @@ quickcheckBgSize :: Spec
 quickcheckBgSize =
     describe "Quickcheck tests for <bg-size>" .
       it "Minified <bg-size> maintains semantical equivalence" $
-        property (prop_minificationEq :: BgSize -> Bool)
+        property (prop_minificationEq :: BgSize -> Property)
 
 bgSizeTests :: Spec
 bgSizeTests =

--- a/tests/Hasmin/Types/ColorSpec.hs
+++ b/tests/Hasmin/Types/ColorSpec.hs
@@ -15,7 +15,7 @@ colorTests :: Spec
 colorTests =
   describe "<color> tests" .
     it "minified color is semantically equivalent" $
-      property (prop_minificationEq :: Color -> Bool)
+      property (prop_minificationEq :: Color -> Property)
 
 colorParserTests :: Spec
 colorParserTests =

--- a/tests/Hasmin/Types/DimensionSpec.hs
+++ b/tests/Hasmin/Types/DimensionSpec.hs
@@ -9,15 +9,15 @@ dimensionTests :: Spec
 dimensionTests =
     describe "Dimension tests with quickcheck" $ do
       it "Minified <length>s are equivalent to the original ones" $
-        property (prop_minificationEq :: Length -> Bool)
+        property (prop_minificationEq :: Length -> Property)
       it "Minified <angle>s are equivalent to the original ones" $
-        property (prop_minificationEq :: Angle -> Bool)
+        property (prop_minificationEq :: Angle -> Property)
       it "Minified <time>s are equivalent to the original ones" $
-        property (prop_minificationEq :: Time -> Bool)
+        property (prop_minificationEq :: Time -> Property)
       it "Minified <frequency>s are equivalent to the original ones" $
-        property (prop_minificationEq :: Frequency -> Bool)
+        property (prop_minificationEq :: Frequency -> Property)
       it "Minified <resolution>s are equivalent to the original ones" $
-        property (prop_minificationEq :: Resolution -> Bool)
+        property (prop_minificationEq :: Resolution -> Property)
 
 spec :: Spec
 spec = do

--- a/tests/Hasmin/Types/FilterFunctionSpec.hs
+++ b/tests/Hasmin/Types/FilterFunctionSpec.hs
@@ -17,7 +17,7 @@ quickcheckFilter :: Spec
 quickcheckFilter =
     describe "Quickcheck <filter-function> tests" .
       it "Minified <filter-function> maintains semantical equivalence" $
-        property (prop_minificationEq :: FilterFunction -> Bool)
+        property (prop_minificationEq :: FilterFunction -> Property)
 
 filterTestsInfo :: [(String, Text, Text)]
 filterTestsInfo =

--- a/tests/Hasmin/Types/PositionSpec.hs
+++ b/tests/Hasmin/Types/PositionSpec.hs
@@ -15,7 +15,7 @@ positionMinificationTests =
     describe "<position> minification" $ do
       mapM_ (matchSpec f) positionMinificationTestsInfo
       modifyMaxSuccess (const 200000) . it "Minified <position> maintains semantical equivalence" $
-        property (prop_minificationEq :: Position -> Bool)
+        property (prop_minificationEq :: Position -> Property)
   where f = minifyWithTestConfig <$> position
 
 positionMinificationTestsInfo :: [(Text, Text)]

--- a/tests/Hasmin/Types/RepeatStyleSpec.hs
+++ b/tests/Hasmin/Types/RepeatStyleSpec.hs
@@ -11,7 +11,7 @@ repeatStyleTests :: Spec
 repeatStyleTests =
     describe "<repeat-style> minification tests" $ do
       it "Minified <repeat-style> maintains semantic equivalence" $
-        property (prop_minificationEq :: RepeatStyle -> Bool)
+        property (prop_minificationEq :: RepeatStyle -> Property)
       mapM_ (matchSpec f) repeatStyleTestsInfo
   where f = minifyWithTestConfig <$> repeatStyle
 

--- a/tests/Hasmin/Types/TimingFunctionSpec.hs
+++ b/tests/Hasmin/Types/TimingFunctionSpec.hs
@@ -19,7 +19,7 @@ quickcheckTimingFunction :: Spec
 quickcheckTimingFunction =
     describe "<timing-function> quickcheck tests" .
       it "Minified <timing-function> maintains semantical equivalence" $
-        property (prop_minificationEq :: TimingFunction -> Bool)
+        property (prop_minificationEq :: TimingFunction -> Property)
 
 timingFunctionTestsInfo :: [(Text, Text)]
 timingFunctionTestsInfo =


### PR DESCRIPTION
This pull request updates the Stack resolver to `lts-22.5` and widens version bounds appropriately.  It also switches the use of `==` with `===` to show which values are different.  This was supported in QuickCheck 2.8, so the lower version bound for QuickCheck should still hold.  No other code was modified, so the lower version bounds for other packages should still hold as well.

Ironically, the master branch does not build with current versions of Stack, or at least it caused a GHC panic on my machine.

This pull request is not quite ready because tests fail.  Not knowing what could be causing the differences, I can't proceed further for now.  (The test failures were the reason for the switch from `==` to `===`, although it didn't help much so far.)

#### Test failure example

```
Failures:

  tests/Hasmin/Types/BasicShapeSpec.hs:19:38: 
  1) Hasmin.Types.BasicShape, <basic-shape> tests, Minified <basic-shape> maintains semantical equivalence
       Falsified (after 12 tests):
         Inset (Right (Length (Number {getRational = (-45) % 8}) REM) :| [Left (Percentage ((-18) % 5))]) (Just (BorderRadius (Left (Percentage (0 % 1)) :| [Right (Length (Number {getRational = 0 % 1}) REM),Left (Percentage ((-23) % 8)),Left (Percentage (22 % 7)),Left (Percentage ((-6) % 7)),Left (Percentage (23 % 6)),Right (Length (Number {getRational = (-29) % 7}) Q),Left (Percentage ((-45) % 8))]) [Left (Percentage ((-7) % 1)),Left (Percentage ((-27) % 7)),Left (Percentage ((-4) % 1)),Left (Percentage ((-49) % 5)),Right (Length (Number {getRational = 19 % 6}) Q),Right (Length (Number {getRational = 11 % 4}) EM),Left (Percentage ((-3) % 1))]))
         Inset (Right (Length (Number {getRational = (-45) % 8}) REM) :| [Left (Percentage ((-18) % 5))]) (Just (BorderRadius (Right NullLength :| [Right NullLength,Left (Percentage ((-23) % 8)),Left (Percentage (22 % 7)),Left (Percentage ((-6) % 7)),Left (Percentage (23 % 6)),Right (Length (Number {getRational = (-29) % 7}) Q),Left (Percentage ((-45) % 8))]) [Left (Percentage ((-7) % 1)),Left (Percentage ((-27) % 7)),Left (Percentage ((-4) % 1)),Left (Percentage ((-49) % 5)),Right (Length (Number {getRational = 19 % 24}) MM),Right (Length (Number {getRational = 11 % 4}) EM),Left (Percentage ((-3) % 1))])) /= Inset (Right (Length (Number {getRational = (-45) % 8}) REM) :| [Left (Percentage ((-18) % 5))]) (Just (BorderRadius (Left (Percentage (0 % 1)) :| [Right (Length (Number {getRational = 0 % 1}) REM),Left (Percentage ((-23) % 8)),Left (Percentage (22 % 7)),Left (Percentage ((-6) % 7)),Left (Percentage (23 % 6)),Right (Length (Number {getRational = (-29) % 7}) Q),Left (Percentage ((-45) % 8))]) [Left (Percentage ((-7) % 1)),Left (Percentage ((-27) % 7)),Left (Percentage ((-4) % 1)),Left (Percentage ((-49) % 5)),Right (Length (Number {getRational = 19 % 6}) Q),Right (Length (Number {getRational = 11 % 4}) EM),Left (Percentage ((-3) % 1))]))

  To rerun use: --match "/Hasmin.Types.BasicShape/<basic-shape> tests/Minified <basic-shape> maintains semantical equivalence/" --seed 137842799

  tests/Hasmin/Types/PositionSpec.hs:17:41: 
  2) Hasmin.Types.Position, <position> minification, Minified <position> maintains semantical equivalence
       Falsified (after 89500 tests):
         Position {origin1 = Nothing, offset1 = Just (Left (Percentage (50 % 1))), origin2 = Just PosBottom, offset2 = Nothing}
         Position {origin1 = Nothing, offset1 = Just (Left (Percentage (50 % 1))), origin2 = Nothing, offset2 = Just (Left (Percentage (100 % 1)))} /= Position {origin1 = Nothing, offset1 = Just (Left (Percentage (50 % 1))), origin2 = Just PosBottom, offset2 = Nothing}

  To rerun use: --match "/Hasmin.Types.Position/<position> minification/Minified <position> maintains semantical equivalence/" --seed 137842799

Randomized with seed 137842799
```